### PR TITLE
Memory-mappable embeddings

### DIFF
--- a/decanlp/cache_embeddings.py
+++ b/decanlp/cache_embeddings.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2018, The Board of Trustees of the Leland Stanford Junior University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+from argparse import ArgumentParser
+import torch
+import numpy as np
+import random
+import logging
+import sys
+from pprint import pformat
+
+from .text import torchtext
+
+logger = logging.getLogger(__name__)
+
+
+def get_args(argv):
+    parser = ArgumentParser(prog=argv[0])
+    parser.add_argument('--seed', default=123, type=int, help='Random seed.')
+    parser.add_argument('--embeddings', default='./decaNLP/.embeddings', type=str, help='where to save embeddings.')
+    parser.add_argument('--small_glove', action='store_true', help='Cache glove.6B.50d')
+    parser.add_argument('--large_glove', action='store_true', help='Cache glove.840B.300d')
+    parser.add_argument('--char', action='store_true', help='Cache character embeddings')
+
+    args = parser.parse_args(argv[1:])
+    return args
+
+
+def main(argv=sys.argv):
+    args = get_args(argv)
+    logger.info(f'Arguments:\n{pformat(vars(args))}')
+
+    np.random.seed(args.seed)
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed(args.seed)
+
+    if args.char:
+        torchtext.vocab.CharNGram(cache=args.embeddings)
+    if args.small_glove:
+        torchtext.vocab.GloVe(cache=args.embeddings, name="6B", dim=50)
+    if args.large_glove:
+        torchtext.vocab.GloVe(cache=args.embeddings)
+

--- a/decanlp/tests/test.sh
+++ b/decanlp/tests/test.sh
@@ -11,8 +11,12 @@ function delete {
 }
 
 mkdir -p $SRCDIR/embeddings
-curl -O "https://parmesan.stanford.edu/glove/glove.6B.50d.txt.pt" ; mv glove.6B.50d.txt.pt $SRCDIR/embeddings/
-curl -O "https://parmesan.stanford.edu/glove/charNgram.txt.pt" ; mv charNgram.txt.pt $SRCDIR/embeddings/
+
+for v in glove.6B.50d charNgram ; do
+    for f in vectors itos table ; do
+        curl -O "https://parmesan.stanford.edu/glove/${v}.txt.${f}.npy" ; mv ${v}.txt.${f}.npy $SRCDIR/embeddings/
+    done
+done
 
     TMPDIR=`pwd`
     workdir=`mktemp -d $TMPDIR/decaNLP-tests-XXXXXX`

--- a/decanlp/text/torchtext/vocab.py
+++ b/decanlp/text/torchtext/vocab.py
@@ -16,6 +16,7 @@ from .utils import reporthook
 
 logger = logging.getLogger(__name__)
 
+MAX_WORD_LENGTH = 100
 
 class Vocab(object):
     """Defines a vocabulary object that will be used to numericalize a field.
@@ -309,6 +310,9 @@ class Vectors(object):
                     except:
                         logger.info("Skipping non-UTF8 token {}".format(repr(word)))
                         continue
+
+                if len(word) > MAX_WORD_LENGTH:
+                    continue
                 vectors.extend(float(x) for x in entries)
                 itos.append(word)
 

--- a/decanlp/text/torchtext/vocab.py
+++ b/decanlp/text/torchtext/vocab.py
@@ -219,14 +219,15 @@ class SubwordVocab(Vocab):
 def string_hash(x):
     """ Simple deterministic string hash
 
-    Based on g_str_hash from glib.
+    Based on https://cp-algorithms.com/string/string-hashing.html.
     We need this because str.__hash__ is not deterministic (it varies with each process restart)
     and it uses 8 bytes (which is too much for our uses)
     """
 
-    h = 5381
+    P = 1009
+    h = 0
     for c in x:
-        h = (h << 5) + h + ord(c)
+        h = (h << 10) + h + ord(c) * P
         h = h & 0xFFFFFFFF
     return np.uint32(h)
 

--- a/decanlp/text/torchtext/vocab.py
+++ b/decanlp/text/torchtext/vocab.py
@@ -448,6 +448,7 @@ class Vectors(object):
             self.stoi = HashTable(itos, table)
             self.itos = self.stoi.itos
             self.vectors = torch.from_numpy(vectors)
+            self.dim = self.vectors.size()[1]
 
 
 class GloVe(Vectors):

--- a/decanlp/tool.py
+++ b/decanlp/tool.py
@@ -30,13 +30,14 @@
 
 import sys
 
-from decanlp import convert_to_logical_forms, train, predict, server
+from . import convert_to_logical_forms, train, predict, server, cache_embeddings
 
 subcommands = {
     'convert-to-logical-froms': ('Convert to logical forms (for SQL tasks)', convert_to_logical_forms.main),
     'train': ('Train a model', train.main),
     'predict': ('Evaluate a model, or compute predictions on a test dataset', predict.main),
-    'server': ('Export RPC interface to predict', server.main)
+    'server': ('Export RPC interface to predict', server.main),
+    'cache-embeddings': ('Download and cache embeddings', cache_embeddings.main)
 }
 
 def usage():


### PR DESCRIPTION
This PR changes the on-disk format of cached embedding files, and makes it possible to memory map them. Memory maps allow multiple decanlp processes to share the memory (for example when deploying multiple models on the inference machine), and allow the kernel to reclaim the memory under pressure.