### PR TITLE
docker: Switch to ubi8 (RHEL 8)

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,22 +1,17 @@
-# override this to "nvidia/cuda:10.1-runtime-ubi7" if cuda is desired
-ARG BASE_IMAGE=registry.access.redhat.com/ubi7/ubi:latest
+# override this to "nvidia/cuda:10.1-runtime-ubi8" if cuda is desired
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:latest
 FROM ${BASE_IMAGE}
 
 MAINTAINER Thingpedia Admins <thingpedia-admins@lists.stanford.edu>
 
-# install basic tools
-RUN yum -y install git wget gcc gcc-c++
-
-# add epel repo
-RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -O /tmp/epel-release-latest-7.noarch.rpm
-RUN yum -y install /tmp/epel-release-latest-7.noarch.rpm
-
-# install python3
-RUN yum -y install python36 \
-	python36-numpy \
-	python36-scipy \
-	python36-pip \
-	python36-devel
+# install basic tools and python3
+RUN dnf -y install git wget gcc gcc-c++ \
+	python3 \
+	python3-numpy \
+	python3-scipy \
+	python3-pip \
+	python3-devel \
+	&& rm -fr /var/cache/dnf
 
 # download embeddings
 RUN mkdir -p /usr/local/share/decanlp/embeddings
@@ -36,7 +31,7 @@ RUN ln -s /usr/local/share/decanlp/embeddings /home/decanlp/.embeddings
 # copy source and install
 USER root
 COPY . /opt/decanlp
-RUN pip3 install -e /opt/decanlp
+RUN pip3 install -e /opt/decanlp && rm -fr /root/.cache
 
 USER decanlp
 WORKDIR /home/decanlp

--- a/dockerfiles/hooks/build
+++ b/dockerfiles/hooks/build
@@ -6,7 +6,7 @@ echo "Running in $(pwd)"
 
 case $DOCKER_TAG in
 	*-cuda)
-		docker build --build-arg BASE_IMAGE=nvidia/cuda:10.1-runtime-ubi7 -f $(basename $DOCKERFILE_PATH) -t $IMAGE_NAME ..
+		docker build --build-arg BASE_IMAGE=nvidia/cuda:10.1-runtime-ubi8 -f $(basename $DOCKERFILE_PATH) -t $IMAGE_NAME ..
 	;;
 
 	*)


### PR DESCRIPTION
ubi7 was updated to rhel 7.7, which should contain python36 natively,
but python3 is not part of the ubi repos. Luckily, it is part of the
ubi8 repos instead.